### PR TITLE
Allow super admins to edit other usernames

### DIFF
--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -56,7 +56,15 @@ function bpdev_bpcu_nav_setup() {
 	
 	$settings_link = bp_loggedin_user_domain() . bp_get_settings_slug() . '/';
 	
-	bp_core_new_subnav_item( array( 'name' => __( 'Change Username', 'bpcu' ), 'slug' => BPCU_SLUG, 'parent_url' => $settings_link, 'parent_slug' => $bp->settings->slug, 'screen_function' => 'bpdev_bpcu_settings_screen', 'position' => 30, 'user_has_access' => bp_is_my_profile() ) );
+	bp_core_new_subnav_item( array(
+		'name' => __( 'Change Username', 'bpcu' ),
+		'slug' => BPCU_SLUG,
+		'parent_url' => $settings_link,
+		'parent_slug' => $bp->settings->slug,
+		'screen_function' => 'bpdev_bpcu_settings_screen',
+		'position' => 30,
+		'user_has_access' => apply_filters( 'bpcu_user_has_access', bp_is_my_profile() ),
+	) );
 }
 
 add_action('bp_setup_nav', 'bpdev_bpcu_nav_setup', 11);

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -181,11 +181,18 @@ function bpdev_bpcu_settings_screen() {
 			grant_super_admin( $user_id );
 		}
 
+		// add message
 		bp_core_add_message( __( 'Username Changed Successfully!', 'bpcu' ) );
 
-		do_action( 'bp_username_changed', $new_user_name, $bp->displayed_user->userdata );
+		// fetch the user object just in case plugins altered the user_login
+		$user = new WP_User( $user_id );
 
-		bp_core_redirect( bp_displayed_user_domain() . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
+		// hook for plugins
+		do_action( 'bp_username_changed', $new_user_name, $bp->displayed_user->userdata, $user );
+
+		// redirect
+		// bp_core_get_user_domain() requires the new user_nicename / user_login
+		bp_core_redirect( bp_core_get_user_domain( $user_id, $user->user_nicename, $user->user_login ) . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
 
 		return;
 	}

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -144,13 +144,18 @@ function bpdev_bpcu_settings_screen() {
 			$is_super_admin = true;
 			revoke_super_admin( $user_id );
 		}
-		wp_update_user( $changed ); //it will change nicename properly
-		//update user_login
+
+		/* now, update the user_login / user_nicename in the database */
+
+		// this will update user_nicename
+		// wp_update_user() doesn't update user_login when updating a user... sucks!
+		wp_update_user( $changed );
+
+		// this will update user_login
 		$wpdb->update( $wpdb->users, array( 'user_login' => $new_user_name ), array( 'ID' => $user_id ), array( '%s' ), array( '%d' ) );
 
-		//delete cache
+		// delete object cache
 		wp_cache_delete( $user_id, 'users' );
-
 		wp_cache_delete( 'bp_core_userdata_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_username_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_domain_' . $user_id, 'bp' );
@@ -166,9 +171,6 @@ function bpdev_bpcu_settings_screen() {
 		if( is_multisite() && $is_super_admin ){
 			grant_super_admin( $user_id );
 		}
-
-
-
 
 		bp_core_add_message( __( 'Username Changed Successfully!', 'bpcu' ) );
 

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -155,14 +155,14 @@ function bpdev_bpcu_settings_screen() {
 		wp_cache_delete( 'bp_user_username_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_domain_' . $user_id, 'bp' );
 
-		//reset auth cookie for new user_login
-		wp_set_auth_cookie( $user_id, true, false );
-		//force to reset the global $current_user with the new user details
-		$current_user = null;
-		wp_set_current_user( $user_id ); //reset user
-		$user = wp_get_current_user();
-		//if multisite and the user was super admin, mark him back as super admin
+		// reset auth cookie for new user_login
+		// only do this if the current user is attempting to change their own username
+		if ( bp_is_my_profile() ) {
+			wp_set_auth_cookie( $user_id, true, false );
+			wp_set_current_user( $user_id ); //reset user
+		}
 
+		//if multisite and the user was super admin, mark him back as super admin
 		if( is_multisite() && $is_super_admin ){
 			grant_super_admin( $user_id );
 		}

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -90,6 +90,11 @@ function bpdev_bpcu_settings_screen() {
 		//check_admin_referer('bp_settings_change_username');
 
 		$new_user_name = $_POST['bpcu_new_user_name'];
+
+		// username_exists() references the userlogins object cache, so we must clear
+		// it before using the function
+		wp_cache_delete( $new_user_name, 'userlogins' );
+		wp_cache_delete( $_POST['bpcu_current_user_name'], 'userlogins' );
 		
 		//if the username is empty or invalid
 		if ( empty( $new_user_name ) || !validate_username( $new_user_name ) ) {
@@ -146,7 +151,6 @@ function bpdev_bpcu_settings_screen() {
 
 		//delete cache
 		wp_cache_delete( $user_id, 'users' );
-		wp_cache_delete( $user_login, 'userlogins' );
 
 		wp_cache_delete( 'bp_core_userdata_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_username_' . $user_id, 'bp' );

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -63,7 +63,7 @@ function bpdev_bpcu_nav_setup() {
 		'parent_slug' => $bp->settings->slug,
 		'screen_function' => 'bpdev_bpcu_settings_screen',
 		'position' => 30,
-		'user_has_access' => apply_filters( 'bpcu_user_has_access', bp_is_my_profile() ),
+		'user_has_access' => apply_filters( 'bpcu_user_has_access', bp_is_my_profile() || is_super_admin() ),
 	) );
 }
 

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -129,10 +129,7 @@ function bpdev_bpcu_settings_screen() {
 			return;//we don't need this return anyway
 		}
 
-		//if we are here, there is no error and we can change the username
-		//update user_nicename, easy way, let the wp_update_user do it for you
 		$old_user_data = $bp->displayed_user->userdata;
-		$changed = array( 'ID' => $user_id, 'user_login' => $new_user_name, 'user_nicename' => sanitize_title( $new_user_name ) );
 
 		//if it is multisite, before change the username, revoke the admin capability
 		if( is_multisite() && is_super_admin( $user_id ) ) {
@@ -149,9 +146,13 @@ function bpdev_bpcu_settings_screen() {
 
 		// this will update user_nicename
 		// wp_update_user() doesn't update user_login when updating a user... sucks!
-		wp_update_user( $changed );
+		wp_update_user( array(
+			'ID' => $user_id,
+			'user_login' => $new_user_name,
+			'user_nicename' => sanitize_title( $new_user_name )
+		) );
 
-		// this will update user_login
+		// manually update user_login
 		$wpdb->update( $wpdb->users, array( 'user_login' => $new_user_name ), array( 'ID' => $user_id ), array( '%s' ), array( '%d' ) );
 
 		// delete object cache

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -23,7 +23,7 @@ define( 'BPCU_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
  */
 
 function bpdev_bpcu_load_textdomain() {
-	
+
 	$locale = apply_filters( 'bpdev_bpcu_load_textdomain_get_locale', get_locale() );
 	// if load .mo file
 
@@ -43,19 +43,19 @@ add_action( 'bp_init', 'bpdev_bpcu_load_textdomain', 2 );
 
 /**
  * Add sub menu to the User settings page
- * 
+ *
  * @return type
  */
 function bpdev_bpcu_nav_setup() {
-	
+
 	//only add if settings component is enabled
 	if( !bp_is_active( 'settings' ) )
 		return;
-	
+
 	$bp = buddypress();
-	
+
 	$settings_link = bp_displayed_user_domain() . bp_get_settings_slug() . '/';
-	
+
 	bp_core_new_subnav_item( array(
 		'name' => __( 'Change Username', 'bpcu' ),
 		'slug' => BPCU_SLUG,
@@ -71,22 +71,21 @@ add_action('bp_setup_nav', 'bpdev_bpcu_nav_setup', 11);
 
 /**
  * Show/Update Username
- * 
+ *
  * @global type $wpdb
  * @global type $bp
- * @global null $current_user
  * @return type
  */
 function bpdev_bpcu_settings_screen() {
-	
-	global $wpdb, $bp, $current_user;
+
+	global $wpdb, $bp;
 
 	$error          = false;
 	$is_super_admin = false;
 	$user_id        = bp_displayed_user_id();
 
 	if ( isset( $_POST['bpcu_change_username_submit' ] ) ) {
-		
+
 		//check_admin_referer('bp_settings_change_username');
 
 		$new_user_name = $_POST['bpcu_new_user_name'];
@@ -95,38 +94,38 @@ function bpdev_bpcu_settings_screen() {
 		// it before using the function
 		wp_cache_delete( $new_user_name, 'userlogins' );
 		wp_cache_delete( $_POST['bpcu_current_user_name'], 'userlogins' );
-		
+
 		//if the username is empty or invalid
 		if ( empty( $new_user_name ) || !validate_username( $new_user_name ) ) {
-			
+
 			$error = true;
 			$message = __( 'Please enter a valid Username!', 'bpcu' );
-			
+
 		} elseif ( ! $error && $bp->displayed_user->userdata->user_login == $new_user_name ) {
 			//if the provided name is same as the current username
 			$error = true;
 			$message = __( 'Please enter a differnt Username!', 'bpcu' );
-			
+
 		}elseif ( ! $error && username_exists( $new_user_name ) ) {
-			//else if the username already exists 
+			//else if the username already exists
 			$error	 = true;
 			$message = sprintf( __( 'The Username %s already exists. Please use a different username!', 'bpcu' ), $new_user_name );
-			
+
 		} elseif ( ! $error && bpdev_bpcu_is_reserved_name( $new_user_name ) ) {
-			
+
 			$error	 = true;
 			$message = sprintf( __( 'The Username %s is reserved. Please choose a differenet username!' ), $new_user_name );
-			
+
 		}
-		
+
 		//if there was an error
 		//show error &redirect
 		if ( $error ) {
-			
+
 			bp_core_add_message( $message, 'error' );
-			
+
 			bp_core_redirect( bp_displayed_user_domain() . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
-			
+
 			return;//we don't need this return anyway
 		}
 
@@ -137,7 +136,7 @@ function bpdev_bpcu_settings_screen() {
 
 		//if it is multisite, before change the username, revoke the admin capability
 		if( is_multisite() && is_super_admin( $user_id ) ) {
-			
+
 			if( ! function_exists( 'revoke_super_admin' ) ) {
 				require_once( ABSPATH . 'wp-admin/includes/ms.php' );
 			}
@@ -155,7 +154,7 @@ function bpdev_bpcu_settings_screen() {
 		wp_cache_delete( 'bp_core_userdata_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_username_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_domain_' . $user_id, 'bp' );
-				
+
 		//reset auth cookie for new user_login
 		wp_set_auth_cookie( $user_id, true, false );
 		//force to reset the global $current_user with the new user details
@@ -163,20 +162,20 @@ function bpdev_bpcu_settings_screen() {
 		wp_set_current_user( $user_id ); //reset user
 		$user = wp_get_current_user();
 		//if multisite and the user was super admin, mark him back as super admin
-		
+
 		if( is_multisite() && $is_super_admin ){
 			grant_super_admin( $user_id );
 		}
 
 
-		
+
 
 		bp_core_add_message( __( 'Username Changed Successfully!', 'bpcu' ) );
 
 		do_action( 'profile_update', $user_id, $old_user_data );
-		
+
 		bp_core_redirect( bp_displayed_user_domain() . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
-		
+
 		return;
 	}
 	//show title &form
@@ -188,14 +187,14 @@ function bpdev_bpcu_settings_screen() {
 
 /**
  * Change Username form
- * 
+ *
  * @global null $current_user
  */
 function bpdev_bpcu_form() {
 	$bp = buddypress();
 	?>
 	<form name="bpcu_username_changer" method="post" class="standard-form">
-		
+
 		<label for="bpcu_current_user_name"><?php _e("Current User name", "bpcu") ?></label>
 		<input type="text" name="bpcu_current_user_name" id="bpcu_current_user_name" value="<?php echo esc_attr( $bp->displayed_user->userdata->user_login ); ?>" class="settings-input"  disabled="disabled"/>
 
@@ -204,49 +203,49 @@ function bpdev_bpcu_form() {
 
 		<p><?php _e("Enter the new Username of your choice", "bpcu") ?></p>
 		<p class="submit"><input type="submit" id="bpcu_change_username_submit" name="bpcu_change_username_submit" class="button" value="<?php _e('Save Changes', 'bpcu') ?>" /></p>
-	
+
 	</form>
 
 	<?php
 }
 
 /**
- * Settings content title 
+ * Settings content title
  */
 function bpdev_bpcu_title() {
-	
+
 	echo '<h3>' . __( 'Change Username', 'bpcu' ) . '</h3>';
 }
 
 /**
  * Check if Username is reserved
- * 
+ *
  * @param type $username
  * @return boolean
  */
 function bpdev_bpcu_is_reserved_name( $username ) {
-	
+
 	$reserved = array();
-	
+
 	$admin_names = array( 'admin', 'administrator' );
-	
+
 	if ( is_super_admin() && in_array( $username, $admin_names ) )
 		return false; //do not prohibit the super admin from any username
-		
-//other than that, check for all illigal names 
+
+//other than that, check for all illigal names
 	if ( function_exists( 'bp_core_get_illegal_names' ) ) {
-		
+
 		$reserved = bp_core_get_illegal_names();
-	
-		
+
+
 	}elseif ( function_exists( 'bp_core_illegal_names' ) ) {
-		
+
 		$reserved = bp_core_illegal_names();
-		
+
 	}
-	
+
 	if ( in_array( $username, (array) $reserved ) )
 		return true;
-	
+
 	return false;
 }

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -127,7 +127,7 @@ function bpdev_bpcu_settings_screen() {
 
 		//if we are here, there is no error and we can change the username
 		//update user_nicename, easy way, let the wp_update_user do it for you
-		
+		$old_user_data = $bp->displayed_user->userdata;
 		$changed = array( 'ID' => $user_id, 'user_login' => $new_user_name, 'user_nicename' => sanitize_title( $new_user_name ) );
 
 		//if it is multisite, before change the username, revoke the admin capability
@@ -169,9 +169,9 @@ function bpdev_bpcu_settings_screen() {
 
 		bp_core_add_message( __( 'Username Changed Successfully!', 'bpcu' ) );
 
-		do_action( 'profile_update', $user_id, $current_user );
+		do_action( 'profile_update', $user_id, $old_user_data );
 		
-		bp_core_redirect( bp_core_get_user_domain( $user_id, $user->user_nicename, $user->user_login ) . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
+		bp_core_redirect( bp_displayed_user_domain() . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
 		
 		return;
 	}

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -155,6 +155,7 @@ function bpdev_bpcu_settings_screen() {
 		$wpdb->update( $wpdb->users, array( 'user_login' => $new_user_name ), array( 'ID' => $user_id ), array( '%s' ), array( '%d' ) );
 
 		// delete object cache
+		clean_user_cache( $user_id );
 		wp_cache_delete( $user_id, 'users' );
 		wp_cache_delete( 'bp_core_userdata_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_username_' . $user_id, 'bp' );

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -129,8 +129,6 @@ function bpdev_bpcu_settings_screen() {
 			return;//we don't need this return anyway
 		}
 
-		$old_user_data = $bp->displayed_user->userdata;
-
 		//if it is multisite, before change the username, revoke the admin capability
 		if( is_multisite() && is_super_admin( $user_id ) ) {
 
@@ -185,7 +183,7 @@ function bpdev_bpcu_settings_screen() {
 
 		bp_core_add_message( __( 'Username Changed Successfully!', 'bpcu' ) );
 
-		do_action( 'profile_update', $user_id, $old_user_data );
+		do_action( 'bp_username_changed', $new_user_name, $bp->displayed_user->userdata );
 
 		bp_core_redirect( bp_displayed_user_domain() . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
 

--- a/bp-change-username.php
+++ b/bp-change-username.php
@@ -54,7 +54,7 @@ function bpdev_bpcu_nav_setup() {
 	
 	$bp = buddypress();
 	
-	$settings_link = bp_loggedin_user_domain() . bp_get_settings_slug() . '/';
+	$settings_link = bp_displayed_user_domain() . bp_get_settings_slug() . '/';
 	
 	bp_core_new_subnav_item( array(
 		'name' => __( 'Change Username', 'bpcu' ),
@@ -81,9 +81,9 @@ function bpdev_bpcu_settings_screen() {
 	
 	global $wpdb, $bp, $current_user;
 
-	$error			= false;
+	$error          = false;
 	$is_super_admin = false;
-	$user_id		= get_current_user_id();
+	$user_id        = bp_displayed_user_id();
 
 	if ( isset( $_POST['bpcu_change_username_submit' ] ) ) {
 		
@@ -97,7 +97,7 @@ function bpdev_bpcu_settings_screen() {
 			$error = true;
 			$message = __( 'Please enter a valid Username!', 'bpcu' );
 			
-		} elseif ( ! $error && $current_user->user_login == $new_user_name ) {
+		} elseif ( ! $error && $bp->displayed_user->userdata->user_login == $new_user_name ) {
 			//if the provided name is same as the current username
 			$error = true;
 			$message = __( 'Please enter a differnt Username!', 'bpcu' );
@@ -120,7 +120,7 @@ function bpdev_bpcu_settings_screen() {
 			
 			bp_core_add_message( $message, 'error' );
 			
-			bp_core_redirect( bp_core_get_user_domain( $user_id ) . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
+			bp_core_redirect( bp_displayed_user_domain() . $bp->settings->slug . '/' . BPCU_SLUG . '/' );
 			
 			return;//we don't need this return anyway
 		}
@@ -147,7 +147,8 @@ function bpdev_bpcu_settings_screen() {
 		//delete cache
 		wp_cache_delete( $user_id, 'users' );
 		wp_cache_delete( $user_login, 'userlogins' );
-		
+
+		wp_cache_delete( 'bp_core_userdata_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_username_' . $user_id, 'bp' );
 		wp_cache_delete( 'bp_user_domain_' . $user_id, 'bp' );
 				
@@ -187,12 +188,12 @@ function bpdev_bpcu_settings_screen() {
  * @global null $current_user
  */
 function bpdev_bpcu_form() {
-	global $current_user;
+	$bp = buddypress();
 	?>
 	<form name="bpcu_username_changer" method="post" class="standard-form">
 		
 		<label for="bpcu_current_user_name"><?php _e("Current User name", "bpcu") ?></label>
-		<input type="text" name="bpcu_current_user_name" id="bpcu_current_user_name" value="<?php echo esc_attr( $current_user->user_login ); ?>" class="settings-input"  disabled="disabled"/>
+		<input type="text" name="bpcu_current_user_name" id="bpcu_current_user_name" value="<?php echo esc_attr( $bp->displayed_user->userdata->user_login ); ?>" class="settings-input"  disabled="disabled"/>
 
 		<label for="new_user_name"><?php _e("New User name", "bpcu") ?></label>
 		<input type="text" name="bpcu_new_user_name" id="bpcu_new_user_name" value="" class="settings-input" />


### PR DESCRIPTION
Hi Brajesh,

Great plugin!  I made some adjustments so super admins can edit other member's usernames and also fixed some bugs when an object cache is in use.

Let me know what you think or if you have any questions.

-Ray
